### PR TITLE
Add tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The middleware runs the combine function on every request. Since Swagger documen
 
 * **Swagger Combine** requires one configuration schema which resembles a standard Swagger schema except for an additional `apis` field.
 * Since this module uses [Swagger Parser](https://github.com/BigstickCarpet/swagger-parser) and [JSON Schema $Ref Parser](https://github.com/BigstickCarpet/json-schema-ref-parser) internally the schema can be passed to **Swagger Combine** as a file path, a URL or a JS object.
-* All `$ref` fields in the configuration schema are getting dereferenced. 
+* All `$ref` fields in the configuration schema are getting dereferenced.
 * The default path for the configuration file is `docs/swagger.json`.
 * The configuration file can be `JSON` or `YAML`.
 
@@ -103,7 +103,7 @@ apis:
 
 ### Filtering Paths
 
-Paths can be filtered by using an array of paths to `exclude` or `include`. 
+Paths can be filtered by using an array of paths to `exclude` or `include`.
 
 ```json
 {
@@ -230,6 +230,38 @@ Tags can be renamed in the same manner as paths, using the `tags.rename` field.
 }
 ```
 
+### Adding Tags
+
+Tags can be added to all operations in a schema, using the `tags.add` field.
+
+```json
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Swagger Combine Rename Example",
+    "version": "1.0.0"
+  },
+  "apis": [
+    {
+      "url": "http://petstore.swagger.io/v2/swagger.json",
+      "tags": {
+        "add": [
+          "pet"
+        ]
+      }
+    },
+    {
+      "url": "https://api.apis.guru/v2/specs/medium.com/1.0.0/swagger.yaml",
+      "tags": {
+        "add": [
+          "medium"
+        ]
+      }
+    }
+  ]
+}
+```
+
 ### Renaming Security Definitions
 
 Security definitions can be renamed like paths and tags in the `securityDefinitions.rename` field. All usages of the security definition in the paths are renamed as well.
@@ -301,11 +333,11 @@ Security can be specified per path using the `paths.security` field.
 
 **Returns** `promise` with dereferenced and combined schema.
 
-#### config 
+#### config
 
 **`string|object`**
 
-> URL/path to config schema file or config schema object. 
+> URL/path to config schema file or config schema object.
 >
 > **Default:** `docs/swagger.json`
 
@@ -326,11 +358,11 @@ Security can be specified per path using the `paths.security` field.
 
 **Returns** `function(req, res, next)` for usage as middleware.
 
-#### config 
+#### config
 
 **`string|object`**
 
-> URL/path to config schema file or config schema object. 
+> URL/path to config schema file or config schema object.
 >
 > **Default:** `docs/swagger.json`
 

--- a/examples/add-tags.js
+++ b/examples/add-tags.js
@@ -1,0 +1,31 @@
+const swaggerCombine = require('../src/swagger-combine');
+
+const config = (module.exports = {
+  "swagger": "2.0",
+  "info": {
+    "title": "Swagger Combine Rename Example",
+    "version": "1.0.0"
+  },
+  "apis": [
+    {
+      "url": "http://petstore.swagger.io/v2/swagger.json",
+      "tags": {
+        "add": [
+          "pet"
+        ]
+      }
+    },
+    {
+      "url": "https://api.apis.guru/v2/specs/medium.com/1.0.0/swagger.yaml",
+      "tags": {
+        "add": [
+          "medium"
+        ]
+      }
+    }
+  ]
+});
+
+if (!module.parent) {
+  swaggerCombine(config).then(res => console.log(JSON.stringify(res, false, 2))).catch(err => console.error(err));
+}

--- a/src/swagger-combine.js
+++ b/src/swagger-combine.js
@@ -5,6 +5,8 @@ const traverse = require('traverse');
 const urlJoin = require('url-join');
 const _ = require('lodash');
 
+const operationTypes = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch'];
+
 class SwaggerCombine {
   constructor(config, opts) {
     this.config = _.cloneDeep(config);
@@ -169,7 +171,7 @@ class SwaggerCombine {
       if (this.apis[idx].tags && this.apis[idx].tags.add && this.apis[idx].tags.add.length > 0) {
         this.apis[idx].tags.add.forEach(newTagName => {
           traverse(schema).forEach(function traverseSchema() {
-            if (this.parent && this.parent.parent && this.parent.parent.key === 'paths') {
+            if (this.parent && this.parent.parent && this.parent.parent.key === 'paths' && operationTypes.includes(this.key)) {
               const newTags = (this.node.tags && Array.isArray(this.node.tags))
                 ? this.node.tags.concat(newTagName)
                 : [newTagName];

--- a/src/swagger-combine.js
+++ b/src/swagger-combine.js
@@ -20,6 +20,7 @@ class SwaggerCombine {
       .then(() => this.filterParameters())
       .then(() => this.renamePaths())
       .then(() => this.renameTags())
+      .then(() => this.addTags())
       .then(() => this.renameSecurityDefinitions())
       .then(() => this.addSecurityToPaths())
       .then(() => this.addBasePath())
@@ -152,6 +153,28 @@ class SwaggerCombine {
           traverse(schema).forEach(function traverseSchema() {
             if (this.key === 'tags' && Array.isArray(this.node) && this.node.includes(tagNameToRename)) {
               this.update(this.node.map(tag => (tag === tagNameToRename ? newTagName : tag)));
+            }
+          });
+        });
+      }
+
+      return schema;
+    });
+
+    return this;
+  }
+
+  addTags() {
+    this.schemas = this.schemas.map((schema, idx) => {
+      if (this.apis[idx].tags && this.apis[idx].tags.add && this.apis[idx].tags.add.length > 0) {
+        this.apis[idx].tags.add.forEach(newTagName => {
+          traverse(schema).forEach(function traverseSchema() {
+            if (this.parent && this.parent.parent && this.parent.parent.key === 'paths') {
+              const newTags = (this.node.tags && Array.isArray(this.node.tags))
+                ? this.node.tags.concat(newTagName)
+                : [newTagName];
+
+              this.update(Object.assign({}, this.node, { tags: newTags }));
             }
           });
         });

--- a/src/swagger-combine.js
+++ b/src/swagger-combine.js
@@ -154,7 +154,7 @@ class SwaggerCombine {
         _.forIn(this.apis[idx].tags.rename, (newTagName, tagNameToRename) => {
           traverse(schema).forEach(function traverseSchema() {
             if (this.key === 'tags' && Array.isArray(this.node) && this.node.includes(tagNameToRename)) {
-              this.update(this.node.map(tag => (tag === tagNameToRename ? newTagName : tag)));
+              this.update(_.uniq(this.node.map(tag => (tag === tagNameToRename ? newTagName : tag))));
             }
           });
         });
@@ -173,7 +173,7 @@ class SwaggerCombine {
           traverse(schema).forEach(function traverseSchema() {
             if (this.parent && this.parent.parent && this.parent.parent.key === 'paths' && operationTypes.includes(this.key)) {
               const newTags = (this.node.tags && Array.isArray(this.node.tags))
-                ? this.node.tags.concat(newTagName)
+                ? _.uniq(this.node.tags.concat(newTagName))
                 : [newTagName];
 
               this.update(Object.assign({}, this.node, { tags: newTags }));

--- a/test/unit.spec.js
+++ b/test/unit.spec.js
@@ -301,6 +301,27 @@ describe('[Unit] swagger-combine.js', () => {
       });
     });
 
+    describe('addTags()', () => {
+      it('adds tags', () => {
+        instance.apis = [
+          {
+            tags: {
+              add: [
+                'newTag',
+              ],
+            },
+          },
+        ];
+
+        instance.addTags();
+        expect(instance.schemas[0].paths['/test/path/first'].get.tags).to.include('newTag');
+        expect(instance.schemas[0].paths['/test/path/first'].post.tags).to.include('newTag');
+        expect(instance.schemas[0].paths['/test/path/second'].get.tags).to.include('newTag');
+        expect(instance.schemas[0].paths['/test/path/second'].post.tags).to.include('newTag');
+        expect(instance.schemas[0].paths['/test/path/second'].get.tags).to.have.lengthOf(3);
+      });
+    });
+
     describe('renameSecurityDefinitions()', () => {
       beforeEach(() => {
         instance.apis = [

--- a/test/unit.spec.js
+++ b/test/unit.spec.js
@@ -305,6 +305,23 @@ describe('[Unit] swagger-combine.js', () => {
         expect(instance.schemas[0].paths['/test/path/second'].get.tags).to.include('testTagRenamed');
         expect(instance.schemas[0].paths['/test/path/second'].get.tags).to.have.lengthOf(2);
       });
+
+      it('filters out duplicate tags', () => {
+        instance.apis = [
+          {
+            tags: {
+              rename: {
+                testTagFirst: 'testTagSecond',
+              },
+            },
+          },
+        ];
+
+        instance.renameTags();
+        expect(instance.schemas[0].paths['/test/path/second'].get.tags).to.not.include('testTagFirst');
+        expect(instance.schemas[0].paths['/test/path/second'].get.tags).to.include('testTagSecond');
+        expect(instance.schemas[0].paths['/test/path/second'].get.tags).to.have.lengthOf(1);
+      });
     });
 
     describe('addTags()', () => {
@@ -327,6 +344,27 @@ describe('[Unit] swagger-combine.js', () => {
         expect(instance.schemas[0].paths['/test/path/second'].get.tags).to.include('newTag');
         expect(instance.schemas[0].paths['/test/path/second'].post.tags).to.include('newTag');
         expect(instance.schemas[0].paths['/test/path/second'].get.tags).to.have.lengthOf(3);
+      });
+
+      it('filters out duplicate tags', () => {
+        instance.apis = [
+          {
+            tags: {
+              add: [
+                'testTagFirst',
+              ],
+            },
+          },
+        ];
+
+        instance.addTags();
+        expect(instance.schemas[0].paths['/test/path/first'].get.tags).to.include('testTagFirst');
+        expect(instance.schemas[0].paths['/test/path/first'].post.tags).to.include('testTagFirst');
+        expect(instance.schemas[0].paths['/test/path/first'].parameters).to.have.lengthOf(1);
+
+        expect(instance.schemas[0].paths['/test/path/second'].get.tags).to.include('testTagFirst');
+        expect(instance.schemas[0].paths['/test/path/second'].post.tags).to.include('testTagFirst');
+        expect(instance.schemas[0].paths['/test/path/second'].get.tags).to.have.lengthOf(2);
       });
     });
 

--- a/test/unit.spec.js
+++ b/test/unit.spec.js
@@ -57,6 +57,12 @@ describe('[Unit] swagger-combine.js', () => {
                   },
                 ],
               },
+              parameters: [
+                {
+                  name: 'sharedParam',
+                  in: 'query',
+                },
+              ],
             },
             '/test/path/second': {
               get: {
@@ -175,7 +181,7 @@ describe('[Unit] swagger-combine.js', () => {
 
         instance.filterPaths();
         expect(instance.schemas[0].paths['/test/path/first']).to.not.have.keys('get');
-        expect(Object.keys(instance.schemas[0].paths['/test/path/first'])).to.have.lengthOf(1);
+        expect(Object.keys(instance.schemas[0].paths['/test/path/first'])).to.have.lengthOf(2);
         expect(Object.keys(instance.schemas[0].paths)).to.have.lengthOf(2);
       });
     });
@@ -316,6 +322,8 @@ describe('[Unit] swagger-combine.js', () => {
         instance.addTags();
         expect(instance.schemas[0].paths['/test/path/first'].get.tags).to.include('newTag');
         expect(instance.schemas[0].paths['/test/path/first'].post.tags).to.include('newTag');
+        expect(instance.schemas[0].paths['/test/path/first'].parameters).to.have.lengthOf(1);
+
         expect(instance.schemas[0].paths['/test/path/second'].get.tags).to.include('newTag');
         expect(instance.schemas[0].paths['/test/path/second'].post.tags).to.include('newTag');
         expect(instance.schemas[0].paths['/test/path/second'].get.tags).to.have.lengthOf(3);


### PR DESCRIPTION
As described in #1, I added support for adding tags to all endpoints of a specific service, like this:

```
{
  "swagger": "2.0",
  "info": {
    "title": "Swagger Combine Rename Example",
    "version": "1.0.0"
  },
  "apis": [
    {
      "url": "http://petstore.swagger.io/v2/swagger.json"
    },
    {
      "url": "https://api.apis.guru/v2/specs/medium.com/1.0.0/swagger.yaml",
      "tags": {
        "add": [
          "Medium"
        ]
      }
    }
  ]
}
```

There are of course two places where tags are used: in the schema root and in every operation. I chose to only add these tags to the operation tags because the root tags will all be merged into a single array anyway (so it doesn't make much sense to allow adding tags per service).

I don't handle the case that an added tag already exists because `renameTags` doesn't handle that either. I also chose to not add a new integration test for this functionality but this can of course be added if needed.