### PR TITLE
Pass api in error

### DIFF
--- a/src/SwaggerCombine.js
+++ b/src/SwaggerCombine.js
@@ -60,6 +60,7 @@ class SwaggerCombine {
                   return;
                 }
 
+                err.api = api.url;
                 throw err;
               });
           })


### PR DESCRIPTION
When you have a long list of apis and something is wrong with one of them, it is hard to figure out where the error is. Returning the url would help a lot in figuring out where the problem is.

I don't expect this would cause problems for any other users of swagger-combine, what do you think?