### PR TITLE
Added ability to have duplicate paths, but not duplicate operations within paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 npm-debug.log
 .nyc_output/
 coverage/
+package-lock.json

--- a/src/SwaggerCombine.js
+++ b/src/SwaggerCombine.js
@@ -9,7 +9,9 @@ const operationTypes = ['get', 'put', 'post', 'delete', 'options', 'head', 'patc
 class SwaggerCombine {
   constructor(config, opts) {
     this.config = _.cloneDeep(config);
-    this.opts = opts || {};
+    this.opts = opts || { 
+      continueOnConflictingPaths: false //set as default
+    };
     this.apis = [];
     this.schemas = [];
     this.combinedSchema = {};
@@ -348,7 +350,14 @@ class SwaggerCombine {
       const conflictingOperationIds = _.intersection(operationIds, newOperationIds);
 
       if (!_.isEmpty(conflictingPaths)) {
-        throw new Error(`Name conflict in paths: ${conflictingPaths.join(', ')}`);
+        if(this.opts.continueOnConflictingPaths) {
+          const conflictingPathOps = _.intersection(_.keys(this.combinedSchema.paths[conflictingPaths]), _.keys(schema.paths[conflictingPaths]));
+          if (!_.isEmpty(conflictingPathOps)) {
+            throw new Error(`Name conflict in paths: ${conflictingPaths.join(', ')} at operation: ${conflictingPathOps.join(', ')}`);
+          }
+        } else {
+          throw new Error(`Name conflict in paths: ${conflictingPaths.join(', ')}`);
+        }
       }
 
       if (!_.isEmpty(conflictingSecurityDefs)) {

--- a/src/SwaggerCombine.js
+++ b/src/SwaggerCombine.js
@@ -9,9 +9,7 @@ const operationTypes = ['get', 'put', 'post', 'delete', 'options', 'head', 'patc
 class SwaggerCombine {
   constructor(config, opts) {
     this.config = _.cloneDeep(config);
-    this.opts = opts || { 
-      continueOnConflictingPaths: false //set as default
-    };
+    this.opts = !_.isEmpty(opts) ? opts.hasOwnProperty('continueOnConflictingPaths') ? opts : opts: Object.assign({}, {continueOnConflictingPaths: false});  //set as default
     this.apis = [];
     this.schemas = [];
     this.combinedSchema = {};

--- a/src/SwaggerCombine.js
+++ b/src/SwaggerCombine.js
@@ -349,9 +349,11 @@ class SwaggerCombine {
 
       if (!_.isEmpty(conflictingPaths)) {
         if(this.opts.continueOnConflictingPaths) {
-          const conflictingPathOps = _.intersection(_.keys(this.combinedSchema.paths[conflictingPaths]), _.keys(schema.paths[conflictingPaths]));
-          if (!_.isEmpty(conflictingPathOps)) {
-            throw new Error(`Name conflict in paths: ${conflictingPaths.join(', ')} at operation: ${conflictingPathOps.join(', ')}`);
+          for(let cPath of conflictingPaths) {
+            const conflictingPathOps = _.intersection(_.keys(this.combinedSchema.paths[cPath]), _.keys(schema.paths[cPath]));
+            if (!_.isEmpty(conflictingPathOps)) {
+                throw new Error(`Name conflict in paths: ${cPath} at operation: ${conflictingPathOps.join(', ')}`);
+            } 
           }
         } else {
           throw new Error(`Name conflict in paths: ${conflictingPaths.join(', ')}`);

--- a/src/SwaggerCombine.js
+++ b/src/SwaggerCombine.js
@@ -9,7 +9,7 @@ const operationTypes = ['get', 'put', 'post', 'delete', 'options', 'head', 'patc
 class SwaggerCombine {
   constructor(config, opts) {
     this.config = _.cloneDeep(config);
-    this.opts = !_.isEmpty(opts) ? opts.hasOwnProperty('continueOnConflictingPaths') ? opts : opts: Object.assign({}, {continueOnConflictingPaths: false});  //set as default
+    this.opts = opts || {};
     this.apis = [];
     this.schemas = [];
     this.combinedSchema = {};

--- a/test/unit/SwaggerCombine.spec.js
+++ b/test/unit/SwaggerCombine.spec.js
@@ -94,17 +94,6 @@ describe('[Unit] SwaggerCombine.js', () => {
       ];
     });
 
-    it('checks to see if opts is still has default property when not nothing is passed in', () => {
-      expect(instance.opts.hasOwnProperty('continueOnConflictingPaths')).to.be.true;
-    });
-
-    it('checks to see if opts.continueOnConflictingPaths equals true', () => {
-      instance.opts = {
-        continueOnConflictingPaths: true
-      }
-      expect(instance.opts.continueOnConflictingPaths).to.be.true;
-    });
-
     describe('combine()', () => {
       beforeEach(() => {
         sandbox.spy(instance, 'load');
@@ -602,8 +591,7 @@ describe('[Unit] SwaggerCombine.js', () => {
         ]);
       });
 
-      it('throws an error if path name already exists and opts propery continueOnConflictingPaths is false', () => {
-        instance.opts = {continueOnConflictingPaths: false};
+      it('throws an error if path name already exists', () => {
         instance.schemas.push({
           paths: {
             '/test/path/first': {

--- a/test/unit/SwaggerCombine.spec.js
+++ b/test/unit/SwaggerCombine.spec.js
@@ -94,6 +94,17 @@ describe('[Unit] SwaggerCombine.js', () => {
       ];
     });
 
+    it('checks to see if opts is still has default property when not nothing is passed in', () => {
+      expect(instance.opts.hasOwnProperty('continueOnConflictingPaths')).to.be.true;
+    });
+
+    it('checks to see if opts.continueOnConflictingPaths equals true', () => {
+      instance.opts = {
+        continueOnConflictingPaths: true
+      }
+      expect(instance.opts.continueOnConflictingPaths).to.be.true;
+    });
+
     describe('combine()', () => {
       beforeEach(() => {
         sandbox.spy(instance, 'load');
@@ -589,17 +600,6 @@ describe('[Unit] SwaggerCombine.js', () => {
           'test_schema_auth',
           'schema_two_auth',
         ]);
-      });
-
-      it('checks to see if opts is still has default property when not nothing is passed in', () => {
-        expect(instance.opts.hasOwnProperty('continueOnConflictingPaths')).to.be.true;
-      });
-
-      it('checks to see if opts.continueOnConflictingPaths equals true', () => {
-        instance.opts = {
-          continueOnConflictingPaths: true
-        }
-        expect(instance.opts.continueOnConflictingPaths).to.be.true;
       });
 
       it('throws an error if path name already exists and opts propery continueOnConflictingPaths is false', () => {

--- a/test/unit/SwaggerCombine.spec.js
+++ b/test/unit/SwaggerCombine.spec.js
@@ -591,6 +591,17 @@ describe('[Unit] SwaggerCombine.js', () => {
         ]);
       });
 
+      it('checks to see if opts is still has default property when not nothing is passed in', () => {
+        expect(instance.opts.hasOwnProperty('continueOnConflictingPaths')).to.be.true;
+      });
+
+      it('checks to see if opts.continueOnConflictingPaths equals true', () => {
+        instance.opts = {
+          continueOnConflictingPaths: true
+        }
+        expect(instance.opts.continueOnConflictingPaths).to.be.true;
+      });
+
       it('throws an error if path name already exists and opts propery continueOnConflictingPaths is false', () => {
         instance.opts = {continueOnConflictingPaths: false};
         instance.schemas.push({

--- a/test/unit/SwaggerCombine.spec.js
+++ b/test/unit/SwaggerCombine.spec.js
@@ -591,7 +591,8 @@ describe('[Unit] SwaggerCombine.js', () => {
         ]);
       });
 
-      it('throws an error if path name already exists', () => {
+      it('throws an error if path name already exists and opts propery continueOnConflictingPaths is false', () => {
+        instance.opts = {continueOnConflictingPaths: false};
         instance.schemas.push({
           paths: {
             '/test/path/first': {
@@ -603,6 +604,36 @@ describe('[Unit] SwaggerCombine.js', () => {
         });
 
         expect(instance.combineSchemas.bind(instance)).to.throw(/Name conflict in paths: \/test\/path\/first/);
+      });
+
+      it('throws an error if path name already exists and opts propery continueOnConflictingPaths is true and there are duplicate operations', () => {
+        instance.opts = { continueOnConflictingPaths: true };
+        instance.schemas.push({
+          paths: {
+            '/test/path/first': {
+              get: {
+                summary: 'GET /test/path/first duplicate',
+              },
+            },
+          },
+        });
+
+        expect(instance.combineSchemas.bind(instance)).to.throw(/Name conflict in paths: \/test\/path\/first at operation: get/);
+      });
+
+      it('accepts duplicate path names if opts propery continueOnConflictingPaths is true and there are not duplicate operations', () => {
+        instance.opts = { continueOnConflictingPaths: true };
+        instance.schemas.push({
+          paths: {
+            '/test/path/first': {
+              patch: {
+                summary: 'PATCH /test/path/first',
+              },
+            },
+          },
+        });
+
+        expect(instance.combineSchemas.bind(instance)).to.not.throw(/Name conflict in paths: \/test\/path\/first at operation: patch/);
       });
 
       it('throws an error if security defintion name with a different configuration already exists', () => {

--- a/test/unit/SwaggerCombine.spec.js
+++ b/test/unit/SwaggerCombine.spec.js
@@ -614,10 +614,24 @@ describe('[Unit] SwaggerCombine.js', () => {
                 summary: 'GET /test/path/first duplicate',
               },
             },
+            '/test/path/second': {
+              get: {
+                summary: 'GET /test/path/first duplicate',
+              }
+            },
           },
         });
 
-        expect(instance.combineSchemas.bind(instance)).to.throw(/Name conflict in paths: \/test\/path\/first at operation: get/);
+        expect(instance.combineSchemas.bind(instance)).to.satisfy((msg) => {
+          if(
+            expect(msg).to.throw(/Name conflict in paths: \/test\/path\/first at operation: get/) ||
+            expect(msg).to.throw(/Name conflict in paths: \/test\/path\/second at operation: get/)
+          ) {
+            return true;
+          } else {
+            return false;
+          };
+        })
       });
 
       it('accepts duplicate path names if opts propery continueOnConflictingPaths is true and there are not duplicate operations', () => {
@@ -628,7 +642,7 @@ describe('[Unit] SwaggerCombine.js', () => {
               patch: {
                 summary: 'PATCH /test/path/first',
               },
-            },
+            },        
           },
         });
 


### PR DESCRIPTION
Have a need to allow duplicate paths when combining swagger definitions but to not then also allow duplicate operations within those paths.  So, i'm submitting this pull request.  This works for me, but there may be a better way to handle this situation that i'm not aware of.

Essentially, I have two sets of json from two different endpoints that looked like this:
```
    "/system/audittrail": {
      "post": {
        "tags": [
          "AuditTrail"
        ],
        "description": "Insert Audit Trail Entries",
        "consumes": [
          "application/json"
        ],
        "parameters": [
          {
            "name": "insertRequest",
            "in": "body",
            "required": true,
            "schema": {
              "$ref": "#/definitions/AuditTrailEntryInsertRequest"
            }
          }
        ],
        "responses": {
          "401": {
            "$ref": "#/responses/401"
          },
          "204": {
            "description": "NoContent"
          }
        },
        "security": [
          {
            "BasicAuth": []
          },
          {
            "SetupTable": [
              "False"
            ]
          },
          {
            "PilotEndpoint": [
              "False"
            ]
          }
        ]
      }
    }
```
and the second looked like this:
```
"/system/audittrail": {
      "get": {
        "tags": [
          "AuditTrail"
        ],
        "description": "Get Audit Trail",
        "produces": [
          "application/json"
        ],
        "parameters": [
          {
            "$ref": "#/parameters/type"
          },
          {
            "$ref": "#/parameters/id"
          },
          {
            "$ref": "#/parameters/deviceIdentifier"
          },
          {
            "$ref": "#/parameters/page"
          },
          {
            "$ref": "#/parameters/pageSize"
          }
        ],
        "responses": {
          "401": {
            "$ref": "#/responses/401"
          },
          "200": {
            "description": "OK",
            "schema": {
              "type": "array",
              "items": {
                "$ref": "#/definitions/AuditTrailEntry"
              }
            },
            "headers": {
              "Link": {
                "description": "Pagination header; potentially includes first, prev, next, and/or last.",
                "type": "string"
              }
            }
          }
        },
        "security": [
          {
            "BasicAuth": []
          },
          {
            "SetupTable": [
              "False"
            ]
          },
          {
            "PilotEndpoint": [
              "False"
            ]
          }
        ]
      }
    },
```

As you can see, they are the same path, but don't duplicate operations.  

I've added a default option to SwaggerCombine that looks like this:
```
       this.opts = !_.isEmpty(opts) ? opts.hasOwnProperty('continueOnConflictingPaths') ? opts : opts: Object.assign({}, {continueOnConflictingPaths: false});  //set as default
```

If no options are passed, then this is set to false as default.  If the `opts.continueOnConflictingPaths` exists it passes that value in withing setting it to the default.

If  `opts.continueOnConflictingPaths` is `true` then you can have duplicate paths, but not duplicate operations as can be seen with this code:

```
      if (!_.isEmpty(conflictingPaths)) {
        if(this.opts.continueOnConflictingPaths) {
          const conflictingPathOps = _.intersection(_.keys(this.combinedSchema.paths[conflictingPaths]), _.keys(schema.paths[conflictingPaths]));
          if (!_.isEmpty(conflictingPathOps)) {
            throw new Error(`Name conflict in paths: ${conflictingPaths.join(', ')} at operation: ${conflictingPathOps.join(', ')}`);
          }
        } else {
          throw new Error(`Name conflict in paths: ${conflictingPaths.join(', ')}`);
        }
      }
```