### PR TITLE
Fix `continueOnError` for extended API config

### DIFF
--- a/src/SwaggerCombine.js
+++ b/src/SwaggerCombine.js
@@ -69,7 +69,7 @@ class SwaggerCombine {
         );
       })
       .then(apis => {
-        this.schemas = apis;
+        this.schemas = apis.filter(api => !!api);
         return this;
       });
   }

--- a/test/integration.spec.js
+++ b/test/integration.spec.js
@@ -51,6 +51,14 @@ describe('[Integration] SwaggerCombine.js', () => {
     return swaggerCombine(basicConfig, { continueOnError: true });
   });
 
+  it('catches errors if `continueOnError` option is set to true and a swagger config is unreachable for extended api config', () => {
+    nock('https://api.apis.guru')
+      .get('/v2/specs/deutschebahn.com/betriebsstellen/v1/swagger.json')
+      .reply(500);
+
+    return swaggerCombine(basicConfig, { continueOnError: true });
+  });
+
   it('catches errors if `continueOnError` option is set to true and a swagger config is invalid', () => {
     nock('http://petstore.swagger.io')
       .get('/v2/swagger.json')


### PR DESCRIPTION
Fixes #43 

Thanks to @maritz 👍 