### PR TITLE
fix: filters down api definitions if schemas are filtered

### DIFF
--- a/src/SwaggerCombine.js
+++ b/src/SwaggerCombine.js
@@ -70,6 +70,7 @@ class SwaggerCombine {
       })
       .then(apis => {
         this.schemas = apis.filter(api => !!api);
+        this.apis = this.apis.filter((_api, idx) => !!apis[idx]);
         return this;
       });
   }

--- a/test/integration.spec.js
+++ b/test/integration.spec.js
@@ -69,6 +69,16 @@ describe('[Integration] SwaggerCombine.js', () => {
     return swaggerCombine(basicConfig, { continueOnError: true });
   });
 
+  it('filters api definitions to match filtered schemas', () => {
+    nock('http://petstore.swagger.io')
+      .get('/v2/swagger.json')
+      .reply(500);
+
+    return swaggerCombine(basicConfig, { continueOnError: true }).then(schema => {
+      expect(schema.paths['/bahn/betriebsstellen']).to.not.be.undefined;
+    });
+  });
+
   it('filters out excluded paths', () =>
     swaggerCombine(filterConfig).then(schema => {
       expect(schema.paths['/pet'].put).to.not.be.ok;


### PR DESCRIPTION
This fixes an issue where api definitions are mapped to the
wrong schema, because the index of the api definition is used to map
it to the index of the schema.
For example when the first defined api is down, the schema for the second
service would still be mapped to the first and thus receive the wrong
basePath (and other options).