### PR TITLE
return error code when error occurs while processing

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -47,7 +47,7 @@ function CLI(argv) {
       console.info(combinedSchema.toString());
     })
     .catch(error => {
-      console.error(error)
+      console.error(error.message)
       process.exit(1);
     });
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -46,7 +46,10 @@ function CLI(argv) {
 
       console.info(combinedSchema.toString());
     })
-    .catch(console.error);
+    .catch(error => {
+      console.error(error)
+      process.exit(1);
+    });
 }
 
 module.exports = CLI;

--- a/test/unit/cli.spec.js
+++ b/test/unit/cli.spec.js
@@ -10,6 +10,7 @@ describe('[Unit] cli.js', () => {
   const expectedYamlOutput = "test: '1'\n";
   const expectedJsonOutput = JSON.stringify(testSchema, null, 2);
   let combineStub;
+  let processExitStub;
   let consoleInfoStub;
   let consoleErrorStub;
   let fsWriteFileSyncStub;
@@ -21,6 +22,7 @@ describe('[Unit] cli.js', () => {
       this.combinedSchema = testSchema;
       return Promise.resolve(this);
     });
+    processExitStub = sinon.stub(process, 'exit');
     consoleInfoStub = sinon.stub(console, 'info');
     consoleErrorStub = sinon.stub(console, 'error');
     fsWriteFileSyncStub = sinon.stub(fs, 'writeFileSync');
@@ -122,12 +124,21 @@ describe('[Unit] cli.js', () => {
     const error = new Error('test error');
     combineStub.rejects(error);
     return CLI(['test.json']).then(() => {
-      expect(consoleErrorStub).to.have.been.calledWith(error);
+      expect(consoleErrorStub).to.have.been.calledWith(error.message);
+    });
+  });
+
+  it('exits process with error code on error', () => {
+    const error = new Error('test error');
+    combineStub.rejects(error);
+    return CLI(['test.json']).then(() => {
+      expect(processExitStub).to.have.been.calledWith(1);
     });
   });
 
   afterEach(() => {
     combineStub.restore();
+    processExitStub.restore();
     consoleInfoStub.restore();
     consoleErrorStub.restore();
     fsWriteFileSyncStub.restore();


### PR DESCRIPTION
addresses the want to have an error code returned via cli if there is an error while processing the included configuration

example config:
```
{
  "swagger": "2.0",
  "info": {
    "title": "Swagger Combine CLI - Returning Error Code",
    "version": "1.0.0"
  },
  "apis": [
    {
      "url": "https://awesomeswagger.invaliddomain/swagger.json",
    }
  ]
}
```

The resulting terminal experience:
```
./bin/swagger-combine .example.json
{
  "code": "ENOTFOUND",
  "errno": "ENOTFOUND",
  "syscall": "getaddrinfo",
  "hostname": "awesomeswagger.invaliddomain",
  "host": "awesomeswagger.invaliddomain",
  "port": 443,
  "api": "https://awesomeswagger.invaliddomain/swagger.json",
  "name": "Error",
  "message": "Error downloading https://awesomeswagger.invaliddomain/swagger.json
getaddrinfo ENOTFOUND awesomeswagger.invaliddomain awesomeswagger.invaliddomain:443",
  "stack": "Error: Error downloading https://awesomeswagger.invaliddomain/swagger.json
getaddrinfo ENOTFOUND awesomeswagger.invaliddomain awesomeswagger.invaliddomain:443
    at /Users/tmack/dev/private/node/swagger-combine/node_modules/json-schema-ref-parser/lib/resolvers/http.js:126:16
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:169:7)

Error: getaddrinfo ENOTFOUND awesomeswagger.invaliddomain awesomeswagger.invaliddomain:443
    at errnoException (dns.js:50:10)
    at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:91:26)"
}
```

Addresses Issue: https://github.com/maxdome/swagger-combine/issues/67.