### PR TITLE
document operationIds.rename functionality in examples and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,35 @@ Tags can be renamed in the same manner as paths with simple, object like configu
 }
 ```
 
+### Renaming Path OperationIds
+
+When merging different swagger definitions there are situations were the operationIds used in these separate swaggers could collide. If this is the case and changing source isn't desired or possible. OperationIds can be renamed by specifying the existing id to rename and the new id as key/value pairs in `operationIds.rename`.
+
+This will replace each operationId matched by the provided key with the new value.
+
+```json
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Swagger Combine Simple OperationId Rename Example",
+    "version": "1.0.0"
+  },
+  "apis": [
+    {
+      "url": "http://petstore.swagger.io/v2/swagger.json",
+      "operationIds": {
+        "rename": {
+          "addPet": "createPet"
+        }
+      }
+    },
+    {
+      "url": "https://api.apis.guru/v2/specs/medium.com/1.0.0/swagger.yaml"
+    }
+  ]
+}
+```
+
 ### Adding Tags
 
 Tags can be added to all operations in a schema, using the `tags.add` field.

--- a/examples/operationIds.js
+++ b/examples/operationIds.js
@@ -1,0 +1,28 @@
+const swaggerCombine = require('../src');
+
+const config = (module.exports = {
+  swagger: '2.0',
+  info: {
+    title: 'Swagger Combine Rename OperationId Example',
+    version: {
+      $ref: './package.json#/version',
+    },
+  },
+  apis: [
+    {
+      url: 'http://petstore.swagger.io/v2/swagger.json',
+      paths: {
+        include: "/pet.post"
+      },
+      operationIds: {
+        rename: {
+          'addPet': 'createPet',
+        },
+      }
+    }
+  ],
+});
+
+if (!module.parent) {
+  swaggerCombine(config).then(res => console.log(JSON.stringify(res, false, 2))).catch(err => console.error(err));
+}


### PR DESCRIPTION
As per https://github.com/maxdome/swagger-combine/issues/71 I was running into this issue and didn't know from the documentation that it was possible to override the value of the operationIds. In a lot of the scenarios the source swagger files had bad operationIds (eg. 'get', 'delete', 'post', 'create', 'getItem'). Though after looking at the source code I found this feature and thought it would be good to call it out on the main README documentation and provide example node samples on how to use it.