### PR TITLE
include/exclude paths based on provided regex strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Example of using Regex Strings (in combination with path string)
       "url": "http://petstore.swagger.io/v2/swagger.json",
       "paths": {
         "exclude": [
-          ".*\{petId\}"
+          ".*\{petId\}.get"
         ]
       }
     },

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ apis:
 
 ### Filtering Paths
 
-Paths can be filtered by using an array of paths to `exclude` or `include`.
+Paths can be filtered by using an array of paths and regex strings to `exclude` or `include`.
 
 ```json
 {
@@ -185,6 +185,37 @@ Paths can be filtered by using an array of paths to `exclude` or `include`.
       "paths": {
         "include": [
           "/users/{userId}/publications",
+          "/me.get"
+        ]
+      }
+    }
+  ]
+}
+```
+
+Example of using Regex Strings (in combination with path string)
+
+```json
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Swagger Combine Filter Example",
+    "version": "1.0.0"
+  },
+  "apis": [
+    {
+      "url": "http://petstore.swagger.io/v2/swagger.json",
+      "paths": {
+        "exclude": [
+          ".*\{petId\}"
+        ]
+      }
+    },
+    {
+      "url": "https://api.apis.guru/v2/specs/medium.com/1.0.0/swagger.yaml",
+      "paths": {
+        "include": [
+          ".*?/publications(/.*)?",
           "/me.get"
         ]
       }

--- a/examples/regexFilter.js
+++ b/examples/regexFilter.js
@@ -1,0 +1,29 @@
+const swaggerCombine = require('../src');
+
+const config = (module.exports = {
+  swagger: '2.0',
+  info: {
+    title: 'Swagger Combine Filter Example',
+    version: {
+      $ref: './package.json#/version',
+    },
+  },
+  apis: [
+    {
+      url: 'http://petstore.swagger.io/v2/swagger.json',
+      paths: {
+        include: ['.*\{petId\}']
+      },
+    },
+    {
+      url: 'https://api.apis.guru/v2/specs/medium.com/1.0.0/swagger.yaml',
+      paths: {
+        exclude: ['.*?/publications(/.*)?'],
+      },
+    },
+  ],
+});
+
+if (!module.parent) {
+  swaggerCombine(config).then(res => console.log(JSON.stringify(res, false, 2))).catch(err => console.error(err));
+}

--- a/examples/regexFilter.js
+++ b/examples/regexFilter.js
@@ -12,7 +12,7 @@ const config = (module.exports = {
     {
       url: 'http://petstore.swagger.io/v2/swagger.json',
       paths: {
-        include: ['.*\{petId\}']
+        include: ['.*\{petId\}.get']
       },
     },
     {

--- a/src/SwaggerCombine.js
+++ b/src/SwaggerCombine.js
@@ -83,29 +83,14 @@ class SwaggerCombine {
     this.schemas = this.schemas.map((schema, idx) => {
       if (this.apis[idx].paths) {
         if (this.apis[idx].paths.include && this.apis[idx].paths.include.length > 0) {
-          
-          // expand all includes into explicit "<path>.<method>" include instructions
-          const dotPaths = Object.keys(schema.paths)
-            .reduce((allDotPaths, currentPath) => {
-              allDotPaths.push(currentPath);
-              const methods = Object.keys(schema.paths[currentPath]).filter(method => operationTypes.includes(method));
-              return allDotPaths.concat(methods.map((method) => `${currentPath}.${method}`))
-            }, []);
-          const explicitIncludes = dotPaths.filter((dotPath) => this.matchInArray(dotPath, this.apis[idx].paths.include));
+          const explicitIncludes = this.expandRegexPathMethod(schema, this.apis[idx].paths.include);
 
           schema.paths = _.merge(
             _.pick(schema.paths, explicitIncludes), 
             _.pickBy(schema.paths, (prop, path) => this.matchInArray(path, explicitIncludes))
           );
         } else if (this.apis[idx].paths.exclude && this.apis[idx].paths.exclude.length > 0) {
-          // expand all excludes into explicit "<path>.<method>" exclude instructions
-          const dotPaths = Object.keys(schema.paths)
-            .reduce((allDotPaths, currentPath) => {
-              allDotPaths.push(currentPath);
-              const methods = Object.keys(schema.paths[currentPath]).filter(method => operationTypes.includes(method));
-              return allDotPaths.concat(methods.map((method) => `${currentPath}.${method}`))
-            }, []);
-          const explicitExcludes = dotPaths.filter((dotPath) => this.matchInArray(dotPath, this.apis[idx].paths.exclude));
+          const explicitExcludes = this.expandRegexPathMethod(schema, this.apis[idx].paths.exclude);
 
           schema.paths = _.omit(schema.paths, explicitExcludes);
           schema.paths = _.omitBy(schema.paths, (prop, path) => this.matchInArray(path, explicitExcludes));
@@ -521,6 +506,18 @@ class SwaggerCombine {
       .omitBy(_.isEmpty)
       .value();
     return this;
+  }
+
+  // Expand `pathMatchList` into a set of defined path.method strings that exist in `schema`
+  expandRegexPathMethod(schema, pathMatchList) {
+    const dotPaths = Object.keys(schema.paths)
+      .reduce((allDotPaths, currentPath) => {
+        allDotPaths.push(currentPath);
+        const methods = Object.keys(schema.paths[currentPath]).filter(method => operationTypes.includes(method));
+        return allDotPaths.concat(methods.map((method) => `${currentPath}.${method}`));
+      }, []);
+    const explicitIncludes = dotPaths.filter((dotPath) => this.matchInArray(dotPath, pathMatchList));
+    return explicitIncludes;
   }
 
   toString(format = this.opts.format) {

--- a/src/SwaggerCombine.js
+++ b/src/SwaggerCombine.js
@@ -75,13 +75,21 @@ class SwaggerCombine {
       });
   }
 
+  matchInArray(string, expressions) {
+    return expressions.filter(obj => new RegExp(obj).test(string)).length != 0;
+  }
+
   filterPaths() {
     this.schemas = this.schemas.map((schema, idx) => {
       if (this.apis[idx].paths) {
         if (this.apis[idx].paths.include && this.apis[idx].paths.include.length > 0) {
-          schema.paths = _.pick(schema.paths, this.apis[idx].paths.include);
+          schema.paths = _.merge(
+            _.pick(schema.paths, this.apis[idx].paths.include), 
+            _.pickBy(schema.paths, (prop, path) => this.matchInArray(path, this.apis[idx].paths.include))
+          );
         } else if (this.apis[idx].paths.exclude && this.apis[idx].paths.exclude.length > 0) {
           schema.paths = _.omit(schema.paths, this.apis[idx].paths.exclude);
+          schema.paths = _.omitBy(schema.paths, (prop, path) => this.matchInArray(path, this.apis[idx].paths.exclude));
         }
       }
 

--- a/test/unit/SwaggerCombine.spec.js
+++ b/test/unit/SwaggerCombine.spec.js
@@ -229,6 +229,20 @@ describe('[Unit] SwaggerCombine.js', () => {
         expect(Object.keys(instance.schemas[0].paths)).to.have.lengthOf(1);
       });
 
+      it('filters included path via regex', () => {
+        instance.apis = [
+          {
+            paths: {
+              include: ['.*?/second'],
+            },
+          },
+        ];
+
+        instance.filterPaths();
+        expect(instance.schemas[0].paths).to.have.all.keys(['/test/path/second']);
+        expect(Object.keys(instance.schemas[0].paths)).to.have.lengthOf(1);
+      });
+
       it('filters included method in path', () => {
         instance.apis = [
           {
@@ -250,6 +264,20 @@ describe('[Unit] SwaggerCombine.js', () => {
           {
             paths: {
               exclude: ['/test/path/first'],
+            },
+          },
+        ];
+
+        instance.filterPaths();
+        expect(instance.schemas[0].paths).to.not.have.keys('/test/path/first');
+        expect(Object.keys(instance.schemas[0].paths)).to.have.lengthOf(1);
+      });
+
+      it('filters out excluded path via regex', () => {
+        instance.apis = [
+          {
+            paths: {
+              exclude: [/.*?/first/],
             },
           },
         ];

--- a/test/unit/SwaggerCombine.spec.js
+++ b/test/unit/SwaggerCombine.spec.js
@@ -259,6 +259,22 @@ describe('[Unit] SwaggerCombine.js', () => {
         expect(Object.keys(instance.schemas[0].paths['/test/path/second'])).to.have.lengthOf(1);
       });
 
+      it('filters included mathod in path via regex ', () => {
+        instance.apis = [
+          {
+            paths: {
+              include: ['.*?/second.get'],
+            },
+          },
+        ];
+
+        instance.filterPaths();
+        expect(instance.schemas[0].paths).to.have.all.keys(['/test/path/second']);
+        expect(instance.schemas[0].paths['/test/path/second']).to.have.all.keys(['get']);
+        expect(Object.keys(instance.schemas[0].paths)).to.have.lengthOf(1);
+        expect(Object.keys(instance.schemas[0].paths['/test/path/second'])).to.have.lengthOf(1);
+      });
+
       it('filters out excluded path', () => {
         instance.apis = [
           {
@@ -292,6 +308,21 @@ describe('[Unit] SwaggerCombine.js', () => {
           {
             paths: {
               exclude: ['/test/path/first.get'],
+            },
+          },
+        ];
+
+        instance.filterPaths();
+        expect(instance.schemas[0].paths['/test/path/first']).to.not.have.keys('get');
+        expect(Object.keys(instance.schemas[0].paths['/test/path/first'])).to.have.lengthOf(2);
+        expect(Object.keys(instance.schemas[0].paths)).to.have.lengthOf(2);
+      });
+
+      it('filters out excluded mathod in path via regex ', () => {
+        instance.apis = [
+          {
+            paths: {
+              exclude: ['.*?first.get'],
             },
           },
         ];

--- a/test/unit/SwaggerCombine.spec.js
+++ b/test/unit/SwaggerCombine.spec.js
@@ -277,7 +277,7 @@ describe('[Unit] SwaggerCombine.js', () => {
         instance.apis = [
           {
             paths: {
-              exclude: [/.*?/first/],
+              exclude: ['.*?/first'],
             },
           },
         ];


### PR DESCRIPTION
I put some thought to having the behavior as described in https://github.com/maxdome/swagger-combine/issues/61 though the issue that I haven't addressed is how to get regex path matching with also matching the method (similar to how the lodash native `_.pick` functions with objects and subpaths. (eg. `/pets/*.get` should match all GET operations on /pet prefixed paths, or `/.*/{id}.get` should match all GET operations on a `<resource>ById` endpoint).

The code I'm proposing will function as the requester asked (include paths based on regex match) this is also behavior I'm looking at having as well instead of having to include each and every path individually now able to match on whitelists instead.

As a work around the above problem a user can combine regex inclusion with path.method exclusion to get to the subset of paths they want to have in the final combined swagger file.

I've added tests for the tests of including and excluding via regex, @fabsrc let me know what other tests you would like for this new functionality or where else you want to have documentation for this behavior as well as the limitations with it.