### PR TITLE
Add '-w | --watch' Flag to Continuously Recombine

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,13 @@ Alternatively the `--format` or `-f` argument can be used:
 $ swagger-combine config.json -f yaml
 ```
 
+#### Watch Source Files and Recombine On Change
+
+```sh
+$ swagger-combine config.json -o combinedSchema.json -w
+```
+
+
 ## Configuration
 
 * **Swagger Combine** requires one configuration schema which resembles a standard Swagger schema except for an additional `apis` field.

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "json-schema-ref-parser": "^6.0.1",
     "lodash": "^4.17.10",
     "minimist": "^1.2.0",
+    "node-watch": "^0.6.0",
     "swagger-parser": "^6.0.1",
     "traverse": "^0.6.6",
     "url-join": "^4.0.0"

--- a/src/SwaggerCombine.js
+++ b/src/SwaggerCombine.js
@@ -13,6 +13,7 @@ class SwaggerCombine {
     this.apis = [];
     this.schemas = [];
     this.combinedSchema = {};
+    this.parsers = [];
   }
 
   combine() {
@@ -36,7 +37,9 @@ class SwaggerCombine {
   }
 
   load() {
-    return $RefParser
+    var parser = new $RefParser();
+    this.parsers.push(parser);
+    return parser
       .dereference(this.config, this.opts)
       .then(configSchema => {
         this.apis = configSchema.apis || [];
@@ -54,11 +57,16 @@ class SwaggerCombine {
               _.set(opts, 'resolve.http.headers.authorization', basicAuth);
             }
 
-            return $RefParser
+            var parser = new $RefParser();
+            this.parsers.push(parser);
+            return parser
               .dereference(api.url, opts)
               .then(res => SwaggerParser.dereference(res, opts))
               .catch(err => {
-                if (this.opts.continueOnError) {
+                if (this.opts.watch) {
+                  console.info('Error in file ', api.url);
+                  return;
+                } else if (this.opts.continueOnError) {
                   return;
                 }
 


### PR DESCRIPTION
I'm not a seasoned JavaScript developer, so I'm happy to receive guidance on this implementation.

We're using swagger-combine in a project and we want to be able to view our changes in near realtime. So we added a `--watch` flag that keeps the process running, keeps track of all files read from disk, watches for changes in them using `node-watch` and re-run's swagger-combine on a change.

To not interrupt the development process when an error is saved to a watched file, we only log them and continue watching.

Happy to add tests once the direction is approved and advice on the solution is given.