### PR TITLE
OpenAPI 3.0 - Add support for root/top/global level tags

### DIFF
--- a/src/SwaggerCombine.js
+++ b/src/SwaggerCombine.js
@@ -490,6 +490,10 @@ class SwaggerCombine {
         this.includeTerm(schema, 'parameters');
       }
 
+      if (this.opts.includeGlobalTags) {
+        this.includeTermArray(schema, 'tags', 'name');
+      }
+
     });
 
     return this;
@@ -508,6 +512,30 @@ class SwaggerCombine {
     }
 
     _.defaultsDeep(this.combinedSchema, _.pick(schema, [term]));
+  }
+
+  includeTermArray(schema, term, matchBy) {
+    if (!_.has(schema, term)) {
+      return
+    }
+
+    const conflictingTerms = _.intersectionBy(
+      this.combinedSchema[term] || [], 
+      _.get(schema, term),
+      matchBy
+    );
+
+    console.log(conflictingTerms);
+
+    if (!_.isEmpty(conflictingTerms)) {
+      throw new Error(`Name conflict in ${term}: ${conflictingTerms.join(', ')}`);
+    }
+
+    if (!_.has(this.combinedSchema, term)) {
+      _.defaultsDeep(this.combinedSchema, _.pick(schema, [term]));
+    } else {
+      this.combinedSchema[term] = this.combinedSchema[term].concat(_.get(schema, term));
+    }
   }
 
   removeEmptyFields() {

--- a/src/SwaggerCombine.js
+++ b/src/SwaggerCombine.js
@@ -525,8 +525,6 @@ class SwaggerCombine {
       matchBy
     );
 
-    console.log(conflictingTerms);
-
     if (!_.isEmpty(conflictingTerms)) {
       throw new Error(`Name conflict in ${term}: ${conflictingTerms.join(', ')}`);
     }

--- a/test/unit/SwaggerCombine.spec.js
+++ b/test/unit/SwaggerCombine.spec.js
@@ -90,6 +90,12 @@ describe('[Unit] SwaggerCombine.js', () => {
               type: 'apiKey',
             },
           },
+          tags: [
+            {
+              name: 'tag name',
+              description: 'tag description'
+            }
+          ]
         },
       ];
     });
@@ -1021,6 +1027,39 @@ describe('[Unit] SwaggerCombine.js', () => {
           });
 
           expect(instance.combineSchemas.bind(instance)).to.throw(/OperationID conflict: getFirst/);
+        });
+      });
+
+      describe('global tags at root level if option `includeGlobalTags` is true', () => {
+        beforeEach(() => {
+          instance.schemas.push({
+            tags: [
+              {
+                name: 'another tag name',
+                description: 'another tag description'
+              }
+            ],   
+          });
+          instance.opts.includeGlobalTags = true;
+        });
+
+        it('combines tags at root level', () => {
+          instance.combineSchemas();
+          expect(instance.combinedSchema.tags).to.be.ok;
+          expect(Object.keys(instance.combinedSchema.tags)).to.have.length(2);
+        })
+        
+        it('throws an error if a global tag name already exists', () => {
+          instance.schemas.push({
+            tags: [
+              {
+                name: 'another tag name',
+                description: 'another tag description'
+              }
+            ],   
+          });
+
+          expect(instance.combineSchemas.bind(instance)).to.throw();
         });
       });
 


### PR DESCRIPTION
https://swagger.io/docs/specification/grouping-operations-with-tags

#87 

I followed the current pattern of adding global tag functionality as an option. I can change it to always handle global tags if preferred.
