### PR TITLE
Add CLI flag for includeGlobalTags

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -18,7 +18,7 @@ function CLI(argv) {
 
   if (args.h) {
     console.info(
-      'Usage: swagger-combine <config> [-o|--output file] [-f|--format <yaml|json>] [--continueOnError] [--continueOnConflictingPaths] [--includeDefinitions]'
+      'Usage: swagger-combine <config> [-o|--output file] [-f|--format <yaml|json>] [--continueOnError] [--continueOnConflictingPaths] [--includeDefinitions] [--includeGlobalTags]'
     );
     return;
   }
@@ -36,6 +36,7 @@ function CLI(argv) {
   opts.continueOnConflictingPaths = !!args.continueOnConflictingPaths;
   opts.includeDefinitions = !!args.includeDefinitions;
   opts.useBasePath = !!args.useBasePath;
+  opts.includeGlobalTags = !!args.includeGlobalTags;
 
   return new SwaggerCombine(config, opts)
     .combine()

--- a/test/unit/cli.spec.js
+++ b/test/unit/cli.spec.js
@@ -128,6 +128,14 @@ describe('[Unit] cli.js', () => {
     CLI(['test.json', '--useBasePath']);
   });
 
+  it('sets includeGlobalTags option', done => {
+    combineStub.callsFake(function() {
+      expect(this.opts.includeGlobalTags).to.be.true;
+      done();
+    });
+    CLI(['test.json', '--includeGlobalTags']);
+  });
+
   it('logs error message on error', () => {
     const error = new Error('test error');
     combineStub.rejects(error);


### PR DESCRIPTION
Hello!

Ran into trying to use the "includeGlobalTags" (added in #89) from the CLI, but saw that it had not been mapped from the CLI args!

This PR should make it so that all current options are available from the CLI again!

Hope that this is ok! :)